### PR TITLE
Add ACF Meta Field Updater tool

### DIFF
--- a/moj-components/component/AcfFieldUpdater/AcfFieldUpdater.php
+++ b/moj-components/component/AcfFieldUpdater/AcfFieldUpdater.php
@@ -1,0 +1,120 @@
+<?php
+namespace MOJComponents\AcfFieldUpdater;
+
+class AcfFieldUpdater
+{
+    /**
+     * Displays a form in the WordPress admin to update meta keys or meta values..
+     * 
+     * This function provides an interface for site administrators to update meta keys or meta values stored in the
+     * wp_postmeta table. Users can select whether they want to update a meta key or a meta value using a dropdown.
+     * Depending on the selection, appropriate input fields are displayed. After submitting the form, the specified
+     * updates are performed on the database.
+     */
+    public function hale_acf_field_updater_tool() {
+
+        if (!current_user_can('manage_options')) {
+            wp_die(__('You do not have sufficient permissions to access this page.'));
+        }
+    
+        // Check if the user has submitted the form
+        if (isset($_POST['update_acf_field'])) {
+    
+            if (!isset($_POST['acf_field_updater_nonce']) || !wp_verify_nonce($_POST['acf_field_updater_nonce'], 'acf_field_updater_action')) {
+                die('Security check failed');
+            }
+    
+            global $wpdb;
+    
+            $update_type = sanitize_text_field($_POST['update_type']);
+            $old_value = sanitize_text_field($_POST['old_value']);
+            $new_value = sanitize_text_field($_POST['new_value']);
+            $meta_key = sanitize_text_field($_POST['meta_key']);
+    
+            if ($update_type === 'key') {
+                $sql = $wpdb->prepare(
+                    "UPDATE {$wpdb->postmeta}
+                    SET meta_key = %s
+                    WHERE meta_key = %s",
+                    $new_value,
+                    $old_value
+                );
+            } else if ($update_type === 'value') {
+                $sql = $wpdb->prepare(
+                    "UPDATE {$wpdb->postmeta}
+                    SET meta_value = %s
+                    WHERE meta_value = %s AND meta_key = %s",
+                    $new_value,
+                    $old_value,
+                    $meta_key
+                );
+            }
+    
+            // Execute the query
+            $updated_rows = $wpdb->query($sql);
+    
+            // Check for success
+            if ($updated_rows > 0) {
+                echo '<div class="updated"><p>ACF field updated successfully. Rows affected: ' . $updated_rows . '</p></div>';
+            } else {
+                echo '<div class="error"><p>No rows updated. It\'s possible the old meta key or value did not exist or was already updated.</p></div>';
+            }
+        }
+        ?>
+    
+        <div class="wrap">
+            <h1>ACF Meta Field Updater</h1>
+            <p>Run a database update on the current site in the _postmeta table. 
+            <br>Select whether you want to update a meta key or meta value.
+            <br>Once run, all content related to the old meta key or value will
+            <br>be associated with the new meta key or value.</p>
+            <form method="post" action="">
+                <?php wp_nonce_field('acf_field_updater_action', 'acf_field_updater_nonce'); ?>
+                <table class="form-table">
+                    <tr valign="top">
+                        <th scope="row"><label for="update_type">Update Type:</label></th>
+                        <td>
+                            <select id="update_type" name="update_type" onchange="toggleMetaKeyField()" required>
+                                <option value="key">Meta Key</option>
+                                <option value="value">Meta Value</option>
+                            </select>
+                        </td>
+                    </tr>
+                    <tr valign="top" id="meta_key_field" style="display: none;">
+                        <th scope="row"><label for="meta_key">Target Meta Key:</label></th>
+                        <td><input type="text" id="meta_key" name="meta_key" value="" /></td>
+                    </tr>
+                    <tr valign="top">
+                        <th scope="row"><label for="old_value">Old Value:</label></th>
+                        <td><input type="text" id="old_value" name="old_value" value="" required /></td>
+                    </tr>
+                    <tr valign="top">
+                        <th scope="row"><label for="new_value">New Value:</label></th>
+                        <td><input type="text" id="new_value" name="new_value" value="" required /></td>
+                    </tr>
+                </table>
+                <p>
+                    <input type="submit" name="update_acf_field" class="button button-primary" value="Update">
+                </p>
+            </form>
+        </div>
+        <script type="text/javascript">
+            function toggleMetaKeyField() {
+                var updateType = document.getElementById('update_type').value;
+                var metaKeyField = document.getElementById('meta_key_field');
+                if (updateType === 'value') {
+                    metaKeyField.style.display = 'table-row';
+                    document.getElementById('meta_key').required = true;
+                } else {
+                    metaKeyField.style.display = 'none';
+                    document.getElementById('meta_key').required = false;
+                }
+            }
+            // Initialize the display state based on the selected option
+            document.addEventListener('DOMContentLoaded', function() {
+                toggleMetaKeyField();
+            });
+        </script>
+        <?php
+    }
+}

--- a/moj-components/component/AdminSettings/AdminSettings.php
+++ b/moj-components/component/AdminSettings/AdminSettings.php
@@ -4,6 +4,7 @@ namespace MOJComponents\AdminSettings;
 
 use MOJComponents\TaxonomyUpdater\TaxonomyUpdater;
 use MOJComponents\ImportUsers\ImportUsers;
+use MOJComponents\AcfFieldUpdater\AcfFieldUpdater;
 
 class AdminSettings
 {
@@ -38,6 +39,7 @@ class AdminSettings
 
         $taxonomyUpdaterObject = new TaxonomyUpdater();
         $importUsersObject = new ImportUsers();
+        $acfFieldUpdaterObject = new AcfFieldUpdater();
 
         add_menu_page(
             'General settings',
@@ -56,6 +58,15 @@ class AdminSettings
             'manage_options',
             'taxonomy-updater',
             [$taxonomyUpdaterObject, 'hale_taxonomy_updater_tool']
+        );
+
+        add_submenu_page(
+            'mojComponentSettings',
+            'ACF Field Updater',
+            'ACF Field Updater',
+            'manage_options',
+            'acf-field-updater',
+            [$acfFieldUpdaterObject, 'hale_acf_field_updater_tool']
         );
 
         add_submenu_page(

--- a/moj-components/moj-components.php
+++ b/moj-components/moj-components.php
@@ -15,6 +15,7 @@ use MOJComponents\Head\Head;
 use MOJComponents\Introduce\Introduce;
 use MOJComponents\Analytics\Analytics;
 use MOJComponents\TaxonomyUpdater\TaxonomyUpdater;
+use MOJComponents\AcfFieldUpdater\AcfFieldUpdater;
 use MOJComponents\ImportUsers\ImportUsers;
 
 define('MOJ_COMPONENT_PLUGIN_PATH', __FILE__);
@@ -36,3 +37,4 @@ new Introduce();
 new Analytics();
 new TaxonomyUpdater();
 new ImportUsers();
+new AcfFieldUpdater();


### PR DESCRIPTION
* Add a new submenu tool under the Hale Components plugin menu

This tool provides the user with input fields that allows a user to replace meta fields and values in WP. 