### PR TITLE
Add rest api routes

### DIFF
--- a/hale-components.php
+++ b/hale-components.php
@@ -21,6 +21,8 @@ include 'inc/login-settings.php';
 // Only include the network dashboard if this is a multisite setup
 if (is_multisite()) {
     include 'inc/network-dashboard.php'; 
+	include 'inc/register-rest-api-routes.php';
 }
 
 include 'moj-components/moj-components.php'; 
+

--- a/inc/network-dashboard.php
+++ b/inc/network-dashboard.php
@@ -49,44 +49,11 @@ function hc_network_dashboard_page() {
  * Callback function to display the content of the custom dashboard page.
  */
 function hc_network_dashboard_content() {
-    // Check if the WB_CONFIG cookie is present
-    $cookie_present = hc_is_waf_bypass_cookie_present();
-
-    $cookie_message = $cookie_present 
-    ? __('<span class="hc-status-on">ON</span> WB_CONFIG cookie is present.', 'hale-components') 
-    : __('<span class="hc-status-off">OFF</span> WB_CONFIG cookie is not present.', 'hale-components');
-
-
-    // Define text for the WAF bypass information
-    $waf_description_panel_text = 'To avoid WAF rules disrupting editors working in the backend,<br>
-    all logged-in users are assigned the WB_CONFIG cookie. The presence of the WB_CONFIG cookie and value
-    disables WAF running.<br>Subscribers, however, are an exception and are still subject to WAF rules.';
-
-    $waf_body_panel_text = 'The WB_CONFIG cookie is set with a value
-    provided by GitActions.<br> Our ingress configuation uses NGINX to apply a WAF but
-    skips WAF rules if the cookie and the correct value are present.';
-    ?>
-    <div class="wrap">
-        <h1><?php _e( 'Hale Components Network Dashboard', 'hale-components' ); ?></h1>
-        <p><?php _e( 'Hale Components Platform wide network settings page.', 'hale-components' ); ?></p>
-        
-        <!-- Grid layout -->
-        <div class="hc-dashboard-grid">
-            <!-- First row: WAF bypass information -->
-            <div class="hc-dashboard-item">
-                <div class="hc-dashboard-left">
-                    <h4><?php _e( 'WAF Bypass Status', 'hale-components' ); ?></h4>
-                    <p><?php echo $cookie_message; ?></p>
-                </div>
-                <div class="hc-dashboard-right">
-                    <h4><?php _e( 'What is the WB_CONFIG cookie?', 'hale-components' ); ?></h4>
-                    <p><?php echo $waf_description_panel_text; ?></p>
-                    <p><?php echo $waf_body_panel_text; ?></p>
-                </div>
-            </div>
-        </div>
-    </div>
-    <?php
+	echo '<div class="wrap">';	    
+	include plugin_dir_path( __FILE__ ) . '/parts/dashboard-intro.php';
+   	include plugin_dir_path( __FILE__ ) . '/parts/waf-status.php';
+  	include plugin_dir_path( __FILE__ ) . '/parts/api-status.php';
+	echo '</div>';
 }
 
 /**
@@ -105,33 +72,3 @@ function hc_get_env_variable($key, $default = '') {
     return $value;
 }
 
-/**
- * Detect if the WB_CONFIG cookie is present.
- *
- * @return bool True if the cookie is present, false otherwise.
- */
-function hc_is_waf_bypass_cookie_present() {
-    // Check if the WB_CONFIG cookie is set and not empty
-    if (isset($_COOKIE['WB_CONFIG']) && !empty($_COOKIE['WB_CONFIG'])) {
-        return true;
-    }
-
-    return false;
-}
-
-add_action('init', 'hc_set_waf_bypass_cookie');
-
-/**
- * Set a WAF bypass cookie for logged-in users if the setting is enabled.
- * // Excludes subscribers (they will still get WAF)
- */
-function hc_set_waf_bypass_cookie()
-{
-    // Value provided into the container via GitAction secrets
-    $wb_config_env_value = hc_get_env_variable('WB_CONFIG');
-
-    // Setting to edit posts excludes subscribers
-    if (current_user_can('edit_posts')) {
-        setcookie('WB_CONFIG', $wb_config_env_value, time() + DAY_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN);
-    }
-}

--- a/inc/parts/api-status.php
+++ b/inc/parts/api-status.php
@@ -1,0 +1,31 @@
+:<?php
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+   // Define text for the WAF bypass information
+    $waf_description_panel_text = 'To avoid WAF rules disrupting editors working in the backend,<br>
+    all logged-in users are assigned the WB_CONFIG cookie. The presence of the WB_CONFIG cookie and value
+    disables WAF running.<br>Subscribers, however, are an exception and are still subject to WAF rules.';
+
+    $waf_body_panel_text = 'The WB_CONFIG cookie is set with a value
+    provided by GitActions.<br> Our ingress configuation uses NGINX to apply a WAF but
+    skips WAF rules if the cookie and the correct value are present.';
+    ?>
+        <!-- Grid layout -->
+        <div class="hc-dashboard-grid">
+            <!-- First row: WAF bypass information -->
+            <div class="hc-dashboard-item">
+                <div class="hc-dashboard-left">
+                    <h4><?php _e( 'API Status', 'hale-components' ); ?></h4>
+                    <p><?php echo $cookie_message; ?></p>
+                </div>
+                <div class="hc-dashboard-right">
+                    <h4><?php _e( 'What is the WB_CONFIG cookie?', 'hale-components' ); ?></h4>
+                    <p><?php echo $waf_description_panel_text; ?></p>
+                    <p><?php echo $waf_body_panel_text; ?></p>
+                </div>
+            </div>
+        </div>
+

--- a/inc/parts/api-status.php
+++ b/inc/parts/api-status.php
@@ -1,31 +1,52 @@
-:<?php
+<?php
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-   // Define text for the WAF bypass information
-    $waf_description_panel_text = 'To avoid WAF rules disrupting editors working in the backend,<br>
-    all logged-in users are assigned the WB_CONFIG cookie. The presence of the WB_CONFIG cookie and value
-    disables WAF running.<br>Subscribers, however, are an exception and are still subject to WAF rules.';
+// Wait and get rest server info
+if (empty($GLOBALS['wp_rest_server'])) {
+    require_once ABSPATH . 'wp-includes/rest-api.php';
+	$GLOBALS['wp_rest_server'] = new \WP_REST_Server();
+    do_action('rest_api_init', $GLOBALS['wp_rest_server']);
+}
 
-    $waf_body_panel_text = 'The WB_CONFIG cookie is set with a value
-    provided by GitActions.<br> Our ingress configuation uses NGINX to apply a WAF but
-    skips WAF rules if the cookie and the correct value are present.';
-    ?>
-        <!-- Grid layout -->
-        <div class="hc-dashboard-grid">
-            <!-- First row: WAF bypass information -->
-            <div class="hc-dashboard-item">
-                <div class="hc-dashboard-left">
-                    <h4><?php _e( 'API Status', 'hale-components' ); ?></h4>
-                    <p><?php echo $cookie_message; ?></p>
-                </div>
-                <div class="hc-dashboard-right">
-                    <h4><?php _e( 'What is the WB_CONFIG cookie?', 'hale-components' ); ?></h4>
-                    <p><?php echo $waf_description_panel_text; ?></p>
-                    <p><?php echo $waf_body_panel_text; ?></p>
-                </div>
-            </div>
+$wp_rest_server = $GLOBALS['wp_rest_server'];
+
+// Fetch all registered REST API routes
+$routes = $wp_rest_server->get_routes();
+
+// Filter and display only custom routes (e.g., starting with /hc-rest/)
+$custom_routes = array_filter(array_keys($routes), function ($route) {
+    return str_starts_with($route, '/hc-rest/');
+});
+
+$api_endpoint_text = 'This plugin registers a custom rest API "/hc-rest" with Wordpress.<br>
+					 These endpoints support various tools used to support the platform.<br>
+					 As a general rule, extend rather then replace these APIs.';
+?>
+
+<!-- Custom API endpoints section -->
+
+<div class="hc-dashboard-grid">
+
+<div class="hc-dashboard-item">
+    <div class="hc-dashboard-left">
+        <h4><?php _e('API Endpoints', 'hale-components'); ?></h4>
+        <?php if (!empty($custom_routes)) : ?>
+            <ul>
+                <?php foreach ($custom_routes as $route) : ?>
+                    <li><code><?php echo esc_html($route); ?></code></li>
+                <?php endforeach; ?>
+            </ul>
+        <?php else : ?>
+            <p>No custom endpoints registered.</p>
+        <?php endif; ?>
+    </div>
+		<div class="hc-dashboard-right">
+            <h4><?php _e( 'Hale Component custom API endpoints', 'hale-components' ); ?></h4>
+            <p><?php echo $api_endpoint_text; ?></p>
         </div>
+	</div>
+</div>
 

--- a/inc/parts/dashboard-intro.php
+++ b/inc/parts/dashboard-intro.php
@@ -1,0 +1,9 @@
+<?php
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+echo wp_kses_post( __( '<h1>Hale Components Network Dashboard</h1>', 'hale-components' ) );
+echo wp_kses_post( __( '<p>Hale Components Platform wide network settings page.</p>', 'hale-components' ) );
+

--- a/inc/parts/waf-status.php
+++ b/inc/parts/waf-status.php
@@ -1,0 +1,70 @@
+<?php
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Detect if the WB_CONFIG cookie is present.
+ *
+ * @return bool True if the cookie is present, false otherwise.
+ */
+function hc_is_waf_bypass_cookie_present() {
+    // Check if the WB_CONFIG cookie is set and not empty
+    if (isset($_COOKIE['WB_CONFIG']) && !empty($_COOKIE['WB_CONFIG'])) {
+        return true;
+    }
+
+    return false;
+}
+
+add_action('init', 'hc_set_waf_bypass_cookie');
+
+/**
+ * Set a WAF bypass cookie for logged-in users if the setting is enabled.
+ * // Excludes subscribers (they will still get WAF)
+ */
+function hc_set_waf_bypass_cookie()
+{
+    // Value provided into the container via GitAction secrets
+    $wb_config_env_value = hc_get_env_variable('WB_CONFIG');
+
+    // Setting to edit posts excludes subscribers
+    if (current_user_can('edit_posts')) {
+        setcookie('WB_CONFIG', $wb_config_env_value, time() + DAY_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN);
+    }
+}
+
+$cookie_present = hc_is_waf_bypass_cookie_present();
+
+$cookie_message = $cookie_present 
+    ? __('<span class="hc-status-on">ON</span> WB_CONFIG cookie is present.', 'hale-components') 
+    : __('<span class="hc-status-off">OFF</span> WB_CONFIG cookie is not present.', 'hale-components');
+
+
+    // Define text for the WAF bypass information
+    $waf_description_panel_text = 'To avoid WAF rules disrupting editors working in the backend,<br>
+    all logged-in users are assigned the WB_CONFIG cookie. The presence of the WB_CONFIG cookie and value
+    disables WAF running.<br>Subscribers, however, are an exception and are still subject to WAF rules.';
+
+    $waf_body_panel_text = 'The WB_CONFIG cookie is set with a value
+    provided by GitActions.<br> Our ingress configuation uses NGINX to apply a WAF but
+    skips WAF rules if the cookie and the correct value are present.';
+    ?>
+        
+        <!-- Grid layout -->
+        <div class="hc-dashboard-grid">
+            <!-- First row: WAF bypass information -->
+            <div class="hc-dashboard-item">
+                <div class="hc-dashboard-left">
+                    <h4><?php _e( 'WAF Bypass Status', 'hale-components' ); ?></h4>
+                    <p><?php echo $cookie_message; ?></p>
+                </div>
+                <div class="hc-dashboard-right">
+                    <h4><?php _e( 'What is the WB_CONFIG cookie?', 'hale-components' ); ?></h4>
+                    <p><?php echo $waf_description_panel_text; ?></p>
+                    <p><?php echo $waf_body_panel_text; ?></p>
+                </div>
+            </div>
+        </div>
+

--- a/inc/register-rest-api-routes.php
+++ b/inc/register-rest-api-routes.php
@@ -59,12 +59,17 @@ function hale_components_get_api_sites_callback() {
     // Loop through each site and gather relevant details.
     foreach ($sites as $site) {
         $details = get_blog_details($site->blog_id);
-        $url = $details->siteurl;
+		$url = $details->siteurl;
+
+		// Parse the domain from the full URL
+    	$parsed_url = parse_url($url);
+		$domain = $parsed_url['host'] ?? $details->domain;
 
         $data[] = [
             'blog_id' => $site->blog_id,
             'slug'    => $details->path,
-            'url'     => $url,
+			'url'     => $url,
+			'domain'  => $domain,
             'name'    => $details->blogname, // May default to root name if not switched.
         ];
     }
@@ -128,10 +133,15 @@ function hale_components_get_api_domain_callback() {
             continue;
         }
 
+		// Parse the domain from the full URL
+    	$parsed_url = parse_url($url);
+		$domain = $parsed_url['host'] ?? $details->domain;
+
         $data[] = [
             'blog_id' => $site->blog_id,
             'slug'    => $details->path,
             'url'     => $url,
+			'domain'  => $domain,
             'name'    => $details->blogname,
         ];
     }

--- a/inc/register-rest-api-routes.php
+++ b/inc/register-rest-api-routes.php
@@ -1,0 +1,192 @@
+<?php
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+// Hook into the REST API initialization action to register custom endpoints.
+add_action('rest_api_init', 'hale_components_register_rest_api_endpoints');
+
+/**
+ * Registers custom public REST API routes for the hale-components plugin.
+ * Only for WP multisite configurations
+ */
+function hale_components_register_rest_api_endpoints() {
+    // Route to get all sites in the multisite network.
+    register_rest_route('hc-rest/v1', '/sites', [
+        'methods' => 'GET',
+        'callback' => 'hale_components_get_api_sites_callback',
+        'permission_callback' => '__return_true',
+    ]);
+
+    // Route to get only subdirectory-based sites.
+    register_rest_route('hc-rest/v1', '/sites/path', [
+        'methods' => 'GET',
+        'callback' => 'hale_components_get_api_path_callback',
+        'permission_callback' => '__return_true',
+    ]);
+
+    // Route to get only domain-based sites
+    register_rest_route('hc-rest/v1', '/sites/domain', [
+        'methods' => 'GET',
+        'callback' => 'hale_components_get_api_domain_callback',
+        'permission_callback' => '__return_true',
+    ]);
+
+    // Route to get all registered block types.
+    register_rest_route('hc-rest/v1', '/blocks', [
+        'methods' => 'GET',
+        'callback' => 'hale_components_get_api_blocks_callback',
+        'permission_callback' => '__return_true',
+    ]);
+
+    // Route to get only block types registered under the 'mojblocks/' namespace.
+    register_rest_route('hc-rest/v1', '/blocks/moj', [
+        'methods' => 'GET',
+        'callback' => 'hale_components_get_api_moj_blocks_callback',
+        'permission_callback' => '__return_true',
+    ]);
+}
+
+/**
+ * Callback for /sites endpoint.
+ * Returns a list of all sites in the multisite network.
+ */
+function hale_components_get_api_sites_callback() {
+    $sites = get_sites();
+    $data = [];
+
+    // Loop through each site and gather relevant details.
+    foreach ($sites as $site) {
+        $details = get_blog_details($site->blog_id);
+        $url = $details->siteurl;
+
+        $data[] = [
+            'blog_id' => $site->blog_id,
+            'slug'    => $details->path,
+            'url'     => $url,
+            'name'    => $details->blogname, // May default to root name if not switched.
+        ];
+    }
+
+    return rest_ensure_response($data);
+}
+
+/**
+ * Callback for /sites/path endpoint.
+ * Returns a list of all sites installed as subdirectories under the root domain.
+ */
+function hale_components_get_api_path_callback() {
+    // Retrieve all sites
+    $sites = get_sites();
+
+    // Array to store subdirectory-based sites
+    $subdirectory_sites = [];
+
+    // Loop through each site and check for subdirectory-based path
+    foreach ($sites as $site) {
+        // Check for paths other than the root '/', which indicates a subdirectory install
+        if ($site->path && $site->path !== '/') {
+
+            // Switch context to the site to get accurate name and URL
+            switch_to_blog($site->blog_id);
+
+            // Collect and store site details
+            $subdirectory_sites[] = [
+                'blog_id' => $site->blog_id,
+                'slug'    => $site->path,
+                'url'     => get_site_url($site->blog_id),
+                'name'    => get_bloginfo('name', 'raw'), // Retrieves the correct site title
+            ];
+
+            // Restore context to the original site
+            restore_current_blog();
+        }
+    }
+
+    // Return the filtered list of subdirectory sites
+    return rest_ensure_response($subdirectory_sites);
+}
+
+/**
+ * Callback for /sites/domain endpoint.
+ * Returns a list of all sites that are using a unique domain (i.e., not subdirectory-based).
+ */
+function hale_components_get_api_domain_callback() {
+    $sites = get_sites();
+    $data = [];
+
+    foreach ($sites as $site) {
+        $details = get_blog_details($site->blog_id);
+        $url = $details->siteurl;
+
+        // Filter out unwanted domains
+        if (
+            strpos($url, 'hale.docker') !== false ||
+            strpos($url, 'websitebuilder.service.justice.gov.uk') !== false
+        ) {
+            continue;
+        }
+
+        $data[] = [
+            'blog_id' => $site->blog_id,
+            'slug'    => $details->path,
+            'url'     => $url,
+            'name'    => $details->blogname,
+        ];
+    }
+
+    return rest_ensure_response($data);
+}
+
+/**
+ * Callback for /blocks endpoint.
+ * Returns all registered block types in the current site.
+ */
+function hale_components_get_api_blocks_callback() {
+	// Get the block type registry
+    $registry = WP_Block_Type_Registry::get_instance();
+
+    // Get all registered blocks
+    $all_blocks = $registry->get_all_registered();
+
+    $blocks = [];
+
+    foreach ($all_blocks as $block) {
+        $blocks[] = [
+            'name'       => $block->name,
+            'title'      => $block->title ?? '',
+            'category'   => $block->category ?? '',
+            'description'=> $block->description ?? '',
+        ];
+    }
+
+    return rest_ensure_response($blocks);
+}
+
+/**
+ * Callback for /blocks/moj endpoint.
+ * Returns only registered blocks that start with the 'mojblocks/' namespace.
+ */
+function hale_components_get_api_moj_blocks_callback() {
+    $registry = WP_Block_Type_Registry::get_instance();
+    $blocks = $registry->get_all_registered();
+
+	$moj_blocks = array_filter($blocks, function( $block ) {
+    	return str_starts_with( $block->name, 'mojblocks/' );
+	});
+
+	$data = [];
+
+    foreach ($moj_blocks as $block) {
+        $data[] = [
+            'name'        => $block->name,
+            'title'       => $block->title ?? '',
+            'category'    => $block->category ?? '',
+            'description' => $block->description ?? '',
+        ];
+    }
+
+    return rest_ensure_response($data);
+  }
+


### PR DESCRIPTION
Registers new API endpoints when installed. These are as follows:
```
    /hc-rest/v1
    /hc-rest/v1/sites
    /hc-rest/v1/sites/path
    /hc-rest/v1/sites/domain
    /hc-rest/v1/blocks
    /hc-rest/v1/blocks/moj
```
I've also added them to the network dashboard in the backend and tided up the plugin a little.