### PR TITLE
Add Purge Cache Purge Functionality

### DIFF
--- a/hale-components.php
+++ b/hale-components.php
@@ -22,6 +22,7 @@ include 'inc/blocks.php';
 include 'inc/comments.php';
 include 'inc/cloudfront.php';
 include 'inc/disable-user-api.php';
+include 'inc/pagecache-purge.php';
 
 
 // Only include the network dashboard if this is a multisite setup

--- a/inc/pagecache-purge.php
+++ b/inc/pagecache-purge.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Page cache purge
+ *
+ * Clears the OpenResty/Redis full-page cache when a page or post
+ * goes live - manual publish, scheduled publish (WP-Cron), or an
+ * edit to already-published content. Page cache ONLY; this never
+ * touches any object cache.
+ */
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+/*
+ * Why transition_post_status (not save_post): save_post does NOT fire when
+ * WP-Cron publishes a scheduled post. transition_post_status fires for manual
+ * publish, scheduled publish, and edits of already-live content.
+ */
+add_action('transition_post_status', 'hc_pagecache_on_transition', 10, 3);
+/**
+ * @param string  $new_status
+ * @param string  $old_status
+ * @param WP_Post $post
+ */
+function hc_pagecache_on_transition($new_status, $old_status, $post): void
+{
+    // Only act when the result is a live, publicly viewable page/post.
+    if ('publish' !== $new_status) {
+        return;
+    }
+    if (wp_is_post_revision($post) || wp_is_post_autosave($post)) {
+        return;
+    }
+    if (! is_post_type_viewable(get_post_type($post))) {
+        return;
+    }
+    // URLs whose cached HTML is now stale.
+    $paths   = ['/'];                                       // home lists/links new content
+    $paths[] = hc_pagecache_path(get_permalink($post));
+    // Hierarchical pages: ancestors show breadcrumbs / child listings.
+    foreach (get_post_ancestors($post) as $ancestor_id) {
+        $paths[] = hc_pagecache_path(get_permalink($ancestor_id));
+    }
+    hc_pagecache_purge_paths(array_values(array_unique(array_filter($paths))));
+}
+/**
+ * Reduce a full permalink to the path used in the cache key (e.g. "/about/").
+ */
+function hc_pagecache_path($url): string
+{
+    $path = wp_parse_url((string) $url, PHP_URL_PATH);
+    return $path ?: '/';
+}
+/**
+ * DELETE the page-cache keys for the given paths on the current site, and
+ * stamp a purge fence for each path so an in-flight request that started
+ * rendering before this purge can't re-cache stale content afterward.
+ *
+ * RACE THIS CLOSES: a request can MISS and start rendering a path right
+ * before an editor publishes. The Lua cache layer writes that render to
+ * Redis asynchronously, *after* the response is already sent - which can
+ * land after this DEL runs and silently undo the purge with stale HTML.
+ * The fence key (pagecache:fence:{host}:{path}, stamped with Redis's own
+ * clock) lets that deferred write check "was this path purged after I
+ * started?" and skip its own write if so.
+ *
+ * Fail-soft: any Redis error is logged and swallowed so a cache problem can
+ * never block an editor from publishing.
+ *
+ * @param string[] $paths
+ */
+function hc_pagecache_purge_paths(array $paths): void
+{
+    if ('true' !== getenv('PAGECACHE_ENABLED') || empty($paths)) {
+        return;
+    }
+    if (! class_exists('Redis')) {
+        error_log('pagecache purge: phpredis (Redis class) not available');
+        return;
+    }
+    try {
+        $host = getenv('REDIS_HOST') ?: 'redis';
+        $port = (int) (getenv('REDIS_PORT') ?: 6379);
+        // ElastiCache in-transit encryption needs the tls:// scheme.
+        // Local dev sets REDIS_SSL=false.
+        if ('false' !== getenv('REDIS_SSL')) {
+            $host = 'tls://' . $host;
+        }
+        $redis = new Redis();
+        if (! $redis->connect($host, $port, 1.0)) {
+            error_log('pagecache purge: Redis connect failed');
+            return;
+        }
+        if ($auth = getenv('REDIS_AUTH')) {
+            $redis->auth($auth);
+        }
+        // Page cache lives in its own DB; the firewall is db0.
+        $redis->select((int) (getenv('PAGECACHE_DB') ?: 1));
+        $version  = (int) ($redis->get('pagecache:version') ?: 0);
+        $hostname = wp_parse_url(home_url(), PHP_URL_HOST);   // multisite: scope to this site
+        // Fence TTL must outlive the slowest realistic PHP render so a
+        // very slow in-flight request can still be fenced out. 60s is
+        // comfortably above normal render times; raise it if pages are
+        // known to render slower than that.
+        $fenceTtl = (int) (getenv('PAGECACHE_FENCE_TTL') ?: 60);
+        // Redis's own clock, not the web server's wall-clock - avoids
+        // clock drift between this PHP host and the OpenResty pods.
+        $time       = $redis->rawCommand('TIME');
+        $fenceValue = (is_array($time) && isset($time[0]))
+            ? $time[0] . '.' . ($time[1] ?? '0')
+            : null;
+        foreach ($paths as $path) {
+            // Must match the Lua key schemes:
+            //   content key -> pagecache:v{ver}:{host}:{uri}
+            //   fence key   -> pagecache:fence:{host}:{uri}   (unversioned)
+            $contentKey = "pagecache:v{$version}:{$hostname}:{$path}";
+            $fenceKey   = "pagecache:fence:{$hostname}:{$path}";
+            if (null !== $fenceValue) {
+                $redis->set($fenceKey, $fenceValue, ['EX' => $fenceTtl]);
+            } else {
+                error_log('pagecache purge: Redis TIME unavailable, fence not set for ' . $path);
+            }
+            $redis->del($contentKey);
+        }
+        $redis->close();
+    } catch (\Throwable $t) {
+        error_log('pagecache purge failed: ' . $t->getMessage());
+    }
+}

--- a/inc/pagecache-purge.php
+++ b/inc/pagecache-purge.php
@@ -25,6 +25,9 @@ add_action('transition_post_status', 'hc_pagecache_on_transition', 10, 3);
  */
 function hc_pagecache_on_transition($new_status, $old_status, $post): void
 {
+    if ('true' !== getenv('PAGECACHE_ENABLED')) {
+        return;
+    }
     // Only act when the result is a live, publicly viewable page/post.
     if ('publish' !== $new_status) {
         return;


### PR DESCRIPTION
## Purge page cache on publish

Adds `inc/pagecache-purge.php`, which clears the OpenResty/Redis full-page cache
whenever a page goes live or is edited, so editors' changes appear immediately instead
of waiting for the cache TTL to expire. **Page cache only — the object cache is
untouched.**

Triggers when:
manual publish, scheduled publish (WP-Cron), or an edit to already-published content.

### What it does

- Hooks `transition_post_status` (not `save_post`, which doesn't fire for
  WP-Cron scheduled publishes), acting only when the new status is `publish`
  for a publicly viewable post type.
- Deletes cached HTML for the post's permalink, its ancestor pages
  (breadcrumbs / child listings), and the homepage.
- Keys are scoped to the current site's hostname, so it's multisite-safe.

### Race protection

A request can cache-MISS and start rendering just before a publish; the Lua
layer writes that render to Redis *after* the response is sent, which could land
after our `DEL` and re-cache stale HTML. Each purge therefore also stamps a
fence key (`pagecache:fence:{host}:{path}`, TTL 60s, timestamped with Redis's
own clock to avoid host clock drift). The Lua layer's deferred write checks the
fence and skips its write if the path was purged after rendering started.

### Fail-soft

All Redis errors are logged and swallowed — a cache outage can never block
publishing. The feature is inert unless `PAGECACHE_ENABLED=true`.

### Configuration

| Env var | Default | Purpose |
| --- | --- | --- |
| `PAGECACHE_ENABLED` | — | Must be `true` to enable purging |
| `REDIS_HOST` | `redis` | Redis hostname |
| `REDIS_PORT` | `6379` | Redis port |
| `REDIS_AUTH` | — | Auth password, if set |
| `REDIS_SSL` | TLS on | Set `false` for local dev |
| `PAGECACHE_DB` | `1` | Redis DB for the page cache (firewall uses db0) |
| `PAGECACHE_FENCE_TTL` | `60` | Fence lifetime in seconds |